### PR TITLE
fix TS1196: Catch clause variable cannot have a type annotation.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,7 @@ export function activate(context: vscode.ExtensionContext) {
               {}
             );
         panel.webview.html = getWebviewContent(encoded_text, decodedHeader, decodedPayload);
-      } catch (e: any){
+      } catch (e){
         if (e.name === 'InvalidTokenError') {
           vscode.window.showErrorMessage('Invalid Token Error!');
         }


### PR DESCRIPTION
Fix the following error

> error TS1196: Catch clause variable cannot have a type annotation.