### PR TITLE
Human readable unix epoch in JWT decoded payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ All notable changes to the "jwt-debugger" extension will be documented in this f
 
 ## 0.2.0
 
-- Add a new keybind to execute the command `JWT Debugger Decocde`. Now  you can execute the command either in `Command Palette` or with keybind `Ctrl+Shift+d` (Mac: `Cmd+Shift+d`)
+- Add a new keybind to execute the command `JWT Debugger Decode`. Now  you can execute the command either in `Command Palette` or with keybind `Ctrl+Shift+d` (Mac: `Cmd+Shift+d`)
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ or find at [Marketplace](https://marketplace.visualstudio.com/)
 ## Command & Shortcut
 | Command | Shortcut | Description |
 | --- | --- | --- |
-| `JWT Debugger Decocde` | `Ctrl+Shift+d` <br> (Mac: `Cmd+Shift+d`) | Decode selected JWT Token text |
+| `JWT Debugger Decode` | `Ctrl+Shift+d` <br> (Mac: `Cmd+Shift+d`) | Decode selected JWT Token text |
 
-> NOTE:  The command `JWT Debugger Decocde` and its shortcut key are NOT available when there is no selected text. 
+> NOTE:  The command `JWT Debugger Decode` and its shortcut key are NOT available when there is no selected text. 
 
 ## Change Log
 See [Change Log](CHANGELOG.md)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commands": [
       {
         "command": "extension.jwtdebugger.decode",
-        "title": "JWT Debugger Decocde"
+        "title": "JWT Debugger Decode"
       }
     ],
     "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,8 +30,20 @@ export function activate(context: vscode.ExtensionContext) {
 
       try {
         // jwtDocode return the result of JSON.parse() ( JSON.parse() return any )
-        const decodedHeader = jwtDecode(encoded_text, { header: true });
-        const decodedPayload = jwtDecode(encoded_text);
+        const decodedHeader: any = jwtDecode(encoded_text, { header: true });
+        const decodedPayload: any = objectMap(
+          (jwtDecode(encoded_text) as any),
+          (value: any, key) => {
+          switch (key) {
+            case 'nbf':
+            case 'exp':
+            case 'iat':
+              return `${value} (${new Date(value * 1000).toString()})`;
+              break;
+          }
+          return value
+        });
+
         const panel = vscode.window.createWebviewPanel(
               'previewJWTDecoded',
               'Preview JWT Decoded Result',
@@ -48,6 +60,20 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   context.subscriptions.push(disposable);
+}
+
+/**
+ * Applies a function to every element of an object, and returns the object
+ * @param obj Object to iterate on properties
+ * @param fn Function to apply on each property
+ * @returns A typed object
+ */
+export function objectMap<V, R>(obj: { [key: string]: V }, fn: (value: V, key: string, index: number) => R) {
+  return Object.fromEntries(
+    Object.entries(obj).map(
+      ([k, v], i) => [k, fn(v, k, i)]
+    )
+  );
 }
 
 export function deactivate() {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es6",
     "outDir": "out",
     "lib": [
-      "es6"
+      "es2019"
     ],
     "sourceMap": true,
     "rootDir": "src",


### PR DESCRIPTION
Hi ! 
I needed to check the expiration date, issued at, not valid before values of my JWTs. 
Since unix epoch is gibberish to any human reader i needed to have a human readable representation of these values.

Here is a preview of the result

![unix_epoch_to_date_string](https://github.com/yokawasa/vscode-jwt-debugger/assets/9808953/05542c6d-ed2f-46fe-a7f5-a150754c1a3a)

However since the function i added uses `Object.fromEntries()` i had to set the target to ES2019 in the `tsconfig.json`. 
Maybe there's a way to do this in ES6...

Also i fixed small typos 