### PR TITLE
Remove onCommand entries from  activationEvents in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
     "token",
     "decoder"
   ],
-  "activationEvents": [
-    "onCommand:extension.jwtdebugger.decode"
-  ],
+  "activationEvents": [],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [


### PR DESCRIPTION
Remove onCommand entries from  activationEvents in package.json since it's no longer needed since VS Code v1.74
see also https://github.com/microsoft/vscode-docs/blob/vnext/release-notes/v1_74.md